### PR TITLE
Reconfiguring authorization for production hosting environment

### DIFF
--- a/Authorization/ServiceCollectionExtension.cs
+++ b/Authorization/ServiceCollectionExtension.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 namespace Authorization
 {
@@ -70,7 +71,7 @@ namespace Authorization
                     Options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 });
 
-            services.AddScoped<IAuthenticationService, AuthenticationService>();
+            services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<IJwtService, JwtService>();
 
             return services;

--- a/Authorization/Services/AuthService.cs
+++ b/Authorization/Services/AuthService.cs
@@ -10,12 +10,12 @@ using System.Threading.Tasks;
 
 namespace Authorization.Services
 {
-    class AuthenticationService : Interfaces.IAuthenticationService
+    class AuthService : IAuthService
     {
         private readonly IJwtService _jwtService;
         private readonly IUserRepository _userRepository;
 
-        public AuthenticationService(IJwtService jwtService, IUserRepository userRepository)
+        public AuthService(IJwtService jwtService, IUserRepository userRepository)
         {
             _jwtService = jwtService;
             _userRepository = userRepository;

--- a/Authorization/Services/Interfaces/IAuthService.cs
+++ b/Authorization/Services/Interfaces/IAuthService.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Authorization.Services.Interfaces
 {
-    public interface IAuthenticationService
+    public interface IAuthService
     {
         Task<string> Register(RegisterRequest request);
         Task<string> GetToken(AuthenticateResult result);

--- a/Storage/Migrations/20201014104223_InitDatabase.cs
+++ b/Storage/Migrations/20201014104223_InitDatabase.cs
@@ -44,7 +44,7 @@ namespace Storage.Migrations
                     Email = table.Column<string>(nullable: true),
                     Name = table.Column<string>(nullable: true),
                     Nickname = table.Column<string>(nullable: true),
-                    ProviderId = table.Column<string>(nullable: true),
+                    ProviderId = table.Column<int>(nullable: true),
                     ProviderName = table.Column<string>(nullable: true)
                 },
                 constraints: table =>

--- a/Storage/Migrations/20201023171557_ChangeProviderIdToString.Designer.cs
+++ b/Storage/Migrations/20201023171557_ChangeProviderIdToString.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Storage;
 
 namespace Storage.Migrations
 {
     [DbContext(typeof(JudgeContext))]
-    partial class JudgeContextModelSnapshot : ModelSnapshot
+    [Migration("20201023171557_ChangeProviderIdToString")]
+    partial class ChangeProviderIdToString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Storage/Migrations/20201023171557_ChangeProviderIdToString.cs
+++ b/Storage/Migrations/20201023171557_ChangeProviderIdToString.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Storage.Migrations
+{
+    public partial class ChangeProviderIdToString : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderId",
+                table: "Users",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "ProviderId",
+                table: "Users",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldNullable: true);
+        }
+    }
+}

--- a/WebApi/Controllers/CategoriesController.cs
+++ b/WebApi/Controllers/CategoriesController.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Core.Requests;
 using Core.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Storage.Tables;
@@ -9,6 +10,7 @@ using Storage.Tables;
 namespace WebApi.Controllers
 {
     [Route("api/[controller]")]
+    [Authorize]
     [ApiController]
     public class CategoriesController : ControllerBase
     {

--- a/WebApi/Controllers/GamesController.cs
+++ b/WebApi/Controllers/GamesController.cs
@@ -11,6 +11,7 @@ using Storage.Tables;
 namespace WebApi.Controllers
 {
     [Route("api/[controller]")]
+    [Authorize]
     [ApiController]
     public class GamesController : ControllerBase
     {

--- a/WebApi/Controllers/SummariesController.cs
+++ b/WebApi/Controllers/SummariesController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Core.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Storage.Tables;
@@ -7,6 +8,7 @@ using Storage.Tables;
 namespace WebApi.Controllers
 {
     [Route("api/[controller]")]
+    [Authorize]
     [ApiController]
     public class SummariesController : ControllerBase
     {

--- a/WebApi/Hubs/GameHubMaster.cs
+++ b/WebApi/Hubs/GameHubMaster.cs
@@ -5,9 +5,9 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace WebApi.Hubs
 {
+    [Authorize]
     public partial class GameHub : Hub<IGameClient>
     {
-        [Authorize(Policy = "RequireMasterRole")]
         public async Task StartGame(string gameCode, int itemId)
         {
             var gameId = _gameService.FindActiveGameIdByCode(gameCode);
@@ -22,7 +22,6 @@ namespace WebApi.Hubs
             }
         }
 
-        [Authorize(Policy = "RequireMasterRole")]
         public async Task FinishGame(string gameCode)
         {
             var gameId = _gameService.FindActiveGameIdByCode(gameCode);
@@ -38,7 +37,6 @@ namespace WebApi.Hubs
             }
         }
 
-        [Authorize(Policy = "RequireMasterRole")]
         public async Task DisbandGame(string gameCode)
         {
             var gameId = _gameService.FindActiveGameIdByCode(gameCode);
@@ -54,7 +52,6 @@ namespace WebApi.Hubs
             }
         }
 
-        [Authorize(Policy = "RequireMasterRole")]
         public async Task PushItemId(string gameCode, int itemId)
         {
             int gameId = _gameService.FindActiveGameIdByCode(gameCode);

--- a/WebApi/Startup.cs
+++ b/WebApi/Startup.cs
@@ -2,6 +2,7 @@ using Authorization;
 using Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -28,6 +29,17 @@ namespace WebApi
             services.AddCoreLibraryServices();
             services.AddAuthorizationLibraryServices(Configuration);
             services.AddStorageLibraryServices(Configuration.GetConnectionString("JudgeDbConnection"));
+
+            services.AddCors(options =>
+            {
+                options.AddDefaultPolicy(
+                    builder =>
+                    {
+                        builder.AllowAnyOrigin();
+                        builder.AllowAnyHeader();
+                        builder.AllowAnyMethod();
+                    });
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -38,6 +50,11 @@ namespace WebApi
                 app.UseDeveloperExceptionPage();
             }
 
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedProto
+            });
+
             app.UseSwagger();
 
             app.UseSwaggerUI(c =>
@@ -45,6 +62,8 @@ namespace WebApi
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "Judge'em API v1");
                 c.RoutePrefix = string.Empty;
             });
+
+            app.UseCors();
 
             app.UseRouting();
 


### PR DESCRIPTION
This merge request:
1. Generates a new migration to overwrite db snapshot properly
2. Does a slight refactoring: changes IAuthorizationService -> IAuthService to avoid collision with built-in service and tweaks AuthenticationController attributes
3. Configures ForwardedHeaders to save incoming HTTPS header after facebook/google callback
4. Adds temporary default cors policy for client testing