### PR TITLE
Authorization flow change and PlayerProfile assignment

### DIFF
--- a/Authorization/Authorization.csproj
+++ b/Authorization/Authorization.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
     <ProjectReference Include="..\Storage\Storage.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Authorization/Models/FacebookProfile.cs
+++ b/Authorization/Models/FacebookProfile.cs
@@ -1,0 +1,9 @@
+﻿namespace Authorization.Models
+{
+    public class FacebookProfile
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Authorization/Services/AuthService.cs
+++ b/Authorization/Services/AuthService.cs
@@ -25,8 +25,7 @@ namespace Authorization.Services
         {
             var newUser = new User()
             {
-                Email = request.Email,
-                Nickname = request.Nickname,
+                Email = request.Email
             };
             _userRepository.Add(newUser);
             await _userRepository.SaveChangesAsync();

--- a/Authorization/Services/FacebookApiService.cs
+++ b/Authorization/Services/FacebookApiService.cs
@@ -1,0 +1,19 @@
+﻿using System.Net.Http;
+using Authorization.Services.Interfaces;
+
+namespace Authorization.Services
+{
+    public class FacebookApiService : HttpService, IFacebookApiService
+    {
+        public FacebookApiService(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
+        {
+        }
+
+        public HttpRequestMessage PrepareProfileFetchRequest(HttpMethod method, string path, string token)
+        {
+            path += "fields=id,name,email" + "&access_token=" + token;
+            var request = new HttpRequestMessage(method, path);
+            return request;
+        }
+    }
+}

--- a/Authorization/Services/HttpService.cs
+++ b/Authorization/Services/HttpService.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Authorization.Services.Interfaces;
+
+namespace Authorization.Services
+{
+    public class HttpService : IHttpService
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public HttpService(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
+        public async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, string hostname)
+        {
+            HttpClient client = _httpClientFactory.CreateClient();
+            client.BaseAddress = new Uri(hostname);
+            return await client.SendAsync(request);
+        }
+    }
+}

--- a/Authorization/Services/Interfaces/IAuthService.cs
+++ b/Authorization/Services/Interfaces/IAuthService.cs
@@ -1,12 +1,12 @@
-﻿using Authorization.Requests;
-using Microsoft.AspNetCore.Authentication;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Storage.Tables;
 
 namespace Authorization.Services.Interfaces
 {
     public interface IAuthService
     {
-        Task<string> Register(RegisterRequest request);
-        Task<string> GetToken(AuthenticateResult result);
+        string GetUserToken(User user);
+        string GetGuestToken();
+        Task<User> AuthorizeFacebookUser(string accessToken);
     }
 }

--- a/Authorization/Services/Interfaces/IFacebookApiService.cs
+++ b/Authorization/Services/Interfaces/IFacebookApiService.cs
@@ -1,0 +1,9 @@
+﻿using System.Net.Http;
+
+namespace Authorization.Services.Interfaces
+{
+    public interface IFacebookApiService : IHttpService
+    {
+        HttpRequestMessage PrepareProfileFetchRequest(HttpMethod method, string path, string token);
+    }
+}

--- a/Authorization/Services/Interfaces/IHttpService.cs
+++ b/Authorization/Services/Interfaces/IHttpService.cs
@@ -1,0 +1,10 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Authorization.Services.Interfaces
+{
+    public interface IHttpService
+    {
+        Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, string hostname);
+    }
+}

--- a/Authorization/Services/Interfaces/IJwtService.cs
+++ b/Authorization/Services/Interfaces/IJwtService.cs
@@ -1,9 +1,9 @@
-﻿using Storage.Tables;
+﻿using System.Security.Claims;
 
 namespace Authorization.Services.Interfaces
 {
     public interface IJwtService
     {
-        public string GenerateJwtToken(User user);
+        public string GenerateJwtToken(Claim[] claims);
     }
 }

--- a/Authorization/Services/JwtService.cs
+++ b/Authorization/Services/JwtService.cs
@@ -1,7 +1,6 @@
 ﻿using Authorization.Services.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
-using Storage.Tables;
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
@@ -17,20 +16,14 @@ namespace Authorization.Services
         {
             _configuration = configuration;
         }
-        public string GenerateJwtToken(User user)
+
+        public string GenerateJwtToken(Claim[] claims)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
-
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["JwtToken:SecretKey"]));
             var tokenDescriptor = new SecurityTokenDescriptor
             {
-                Subject = new ClaimsIdentity(new Claim[]
-                {
-                    new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
-                    new Claim(ClaimTypes.Name, user.Name.ToString()),
-                    new Claim(ClaimTypes.Email, user.Email.ToString()),
-                    new Claim(ClaimTypes.AuthenticationMethod, user.ProviderName.ToString()),
-                }),
+                Subject = new ClaimsIdentity(claims),
                 Expires = DateTime.Now.AddMinutes(Convert.ToDouble(_configuration["JwtToken:TokenExpiry"])),
                 SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256Signature),
                 Audience = _configuration["JwtToken:Audience"],

--- a/Core/Dto/PlayerProfileDto.cs
+++ b/Core/Dto/PlayerProfileDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Storage.Tables;
+
+namespace Core.Dto
+{
+    public class PlayerProfileDto
+    {
+        public int Id { get; set; }
+        public string Nickname { get; set; }
+        public UserDto User { get; set; }
+
+        public PlayerProfileDto(PlayerProfile playerProfile)
+        {
+            Id = playerProfile.Id;
+            Nickname = playerProfile.Nickname;
+            User = new UserDto(playerProfile.User);
+        }
+    }
+}

--- a/Core/Dto/PlayerProfileDto.cs
+++ b/Core/Dto/PlayerProfileDto.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Storage.Tables;
+﻿using Storage.Tables;
 
 namespace Core.Dto
 {
     public class PlayerProfileDto
     {
-        public int Id { get; set; }
+        public string Id { get; set; }
         public string Nickname { get; set; }
         public UserDto User { get; set; }
 

--- a/Core/Dto/RatingDto.cs
+++ b/Core/Dto/RatingDto.cs
@@ -8,13 +8,13 @@ namespace Core.Dto
     {
         public int Id { get; set; }
         public float TotalScore { get; set; }
-        public UserDto User { get; set; }
+        public PlayerProfileDto PlayerProfile { get; set; }
 
         public RatingDto(Rating rating)
         {
             Id = rating.Id;
             TotalScore = rating.TotalScore;
-            User = new UserDto(rating.User);
+            PlayerProfile = new PlayerProfileDto(rating.PlayerProfile);
         }
     }
 }

--- a/Core/Dto/TokenDto.cs
+++ b/Core/Dto/TokenDto.cs
@@ -1,0 +1,12 @@
+﻿namespace Core.Dto
+{
+    public class TokenDto
+    {
+        public string Token { get; set; }
+
+        public TokenDto(string token)
+        {
+            Token = token;
+        }
+    }
+}

--- a/Core/Dto/UserDto.cs
+++ b/Core/Dto/UserDto.cs
@@ -7,14 +7,12 @@ namespace Core.Dto
         public int Id { get; set; }
         public string Email { get; set; }
         public string Name { get; set; }
-        public string Nickname { get; set; }
 
         public UserDto(User user)
         {
             Id = user.Id;
             Email = user.Email;
             Name = user.Name;
-            Nickname = user.Nickname;
         }
     }
 }

--- a/Core/Helpers/CodeGenerator.cs
+++ b/Core/Helpers/CodeGenerator.cs
@@ -20,5 +20,15 @@ namespace Core.Helpers
 
             return stringBuilder.ToString();
         }
+
+        public static string GenerateNumerical(int length)
+        { ;
+            var random = new Random();
+            int minRange = Convert.ToInt32(Math.Pow(10, length-1));
+            int maxRange = Convert.ToInt32(Math.Pow(10, length)) - 1;
+            int number = random.Next(minRange, maxRange);
+
+            return number.ToString();
+        }
     }
 }

--- a/Core/Requests/PlayerProfileCreateRequest.cs
+++ b/Core/Requests/PlayerProfileCreateRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace Core.Requests
+{
+    public class PlayerProfileCreateRequest
+    {
+        public string Nickname { get; set; }
+        public int GameId { get; set; }
+        public int UserId { get; set; }
+    }
+}

--- a/Core/Requests/RatingCreateRequest.cs
+++ b/Core/Requests/RatingCreateRequest.cs
@@ -9,5 +9,6 @@ namespace Core.Requests
         public List<CategoryRatingCreateRequest> CategoryRatings { get; set; }
 
         public int ItemId { get; set; }
+        public string PlayerProfileId { get; set; }
     }
 }

--- a/Core/ServiceCollectionExtension.cs
+++ b/Core/ServiceCollectionExtension.cs
@@ -13,6 +13,7 @@ namespace Core
             services.AddScoped<IRatingService, RatingService>();
             services.AddScoped<ISummaryService, SummaryService>();
             services.AddScoped<ICategoryService, CategoryService>();
+            services.AddScoped<IPlayerProfileService, PlayerProfileService>();
             return services;
         }
     }

--- a/Core/Services/CategoryService.cs
+++ b/Core/Services/CategoryService.cs
@@ -17,10 +17,12 @@ namespace Core.Services
         }
         public async Task<List<Category>> GetCategoriesByGameId(int gameId)
         {
-            var categories = _categoryRepository
+            var categories = new List<Category>();
+            await Task.Run(() => categories = _categoryRepository
                 .GetAll()
                 .Where(c => c.GameId == gameId)
-                .ToList();
+                .ToList()
+                );
             return categories;
         }
 

--- a/Core/Services/Interfaces/IPlayerProfileService.cs
+++ b/Core/Services/Interfaces/IPlayerProfileService.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Core.Requests;
+using Storage.Tables;
+
+namespace Core.Services.Interfaces
+{
+    public interface IPlayerProfileService
+    {
+        Task<PlayerProfile> CreatePlayerProfile(PlayerProfileCreateRequest request);
+        Task<PlayerProfile> GetPlayerProfile(string id);
+        Task<string> GetProfileIdByUserGame(int userId, int gameId);
+    }
+}

--- a/Core/Services/Interfaces/IRatingService.cs
+++ b/Core/Services/Interfaces/IRatingService.cs
@@ -5,6 +5,6 @@ namespace Core.Services.Interfaces
 {
     public interface IRatingService
     {
-        Task AddRating(RatingCreateRequest request, int userId);
+        Task AddRating(RatingCreateRequest request);
     }
 }

--- a/Core/Services/PlayerProfileService.cs
+++ b/Core/Services/PlayerProfileService.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Core.Requests;
+using Core.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Storage.Repositories.Interfaces;
+using Storage.Tables;
+
+namespace Core.Services
+{
+    public class PlayerProfileService : IPlayerProfileService
+    {
+        private readonly IPlayerProfileRepository _playerProfileRepository;
+
+        public PlayerProfileService(IPlayerProfileRepository playerProfileRepository)
+        {
+            _playerProfileRepository = playerProfileRepository;
+        }
+        public async Task<PlayerProfile> CreatePlayerProfile(PlayerProfileCreateRequest request)
+        {
+            var playerProfile = new PlayerProfile
+            {
+                GameId = request.GameId,
+                Nickname = request.Nickname,
+                UserId = request.UserId > 0 ? request.UserId : default
+            };
+            _playerProfileRepository.Add(playerProfile);
+            await _playerProfileRepository.SaveChangesAsync();
+
+            return playerProfile;
+        }
+
+        public async Task<PlayerProfile> GetPlayerProfile(string id)
+        {
+            var playerProfile = await _playerProfileRepository.Get(pp => pp.Id == id).FirstOrDefaultAsync();
+
+            return playerProfile;
+        }
+
+        public async Task<string> GetProfileIdByUserGame(int userId, int gameId)
+        {
+            string profileId = await _playerProfileRepository.Get(pp => pp.GameId == gameId && pp.UserId == userId)
+                .Select(pp => pp.Id).FirstOrDefaultAsync();
+
+            return profileId;
+        }
+    }
+}

--- a/Core/Services/RatingService.cs
+++ b/Core/Services/RatingService.cs
@@ -22,7 +22,7 @@ namespace Core.Services
             _categoryRepository = categoryRepository;
         }
 
-        public async Task AddRating(RatingCreateRequest request, int playerProfileId)
+        public async Task AddRating(RatingCreateRequest request)
         {
             var categoryRatings = request.CategoryRatings;
                 var categories = _categoryRepository
@@ -35,7 +35,7 @@ namespace Core.Services
                 var rating = new Rating
                 {
                     ItemId = request.ItemId,
-                    PlayerProfileId = playerProfileId,
+                    PlayerProfileId = request.PlayerProfileId,
                     TotalScore = GetTotalScore(scoreWeights)
                 };
                 _ratingRepository.Add(rating);

--- a/Core/Services/RatingService.cs
+++ b/Core/Services/RatingService.cs
@@ -22,7 +22,7 @@ namespace Core.Services
             _categoryRepository = categoryRepository;
         }
 
-        public async Task AddRating(RatingCreateRequest request, int userId)
+        public async Task AddRating(RatingCreateRequest request, int playerProfileId)
         {
             var categoryRatings = request.CategoryRatings;
                 var categories = _categoryRepository
@@ -35,7 +35,7 @@ namespace Core.Services
                 var rating = new Rating
                 {
                     ItemId = request.ItemId,
-                    UserId = userId,
+                    PlayerProfileId = playerProfileId,
                     TotalScore = GetTotalScore(scoreWeights)
                 };
                 _ratingRepository.Add(rating);

--- a/Core/Services/SummaryService.cs
+++ b/Core/Services/SummaryService.cs
@@ -24,7 +24,7 @@ namespace Core.Services
             var game = _gameRepository.Get(g => g.Id == gameId)
                 .Include(g => g.Items)
                 .ThenInclude(i => i.Ratings)
-                .ThenInclude(r => r.User)
+                .ThenInclude(r => r.PlayerProfile)
                 .FirstOrDefault();
             var gameDto = new GameDto(game);
             string jsonResult = JsonSerializer.Serialize(gameDto);

--- a/Storage/JudgeContext.cs
+++ b/Storage/JudgeContext.cs
@@ -22,6 +22,21 @@ namespace Storage
                 .HasOne(cr => cr.Rating)
                 .WithMany(r => r.CategoryRatings)
                 .HasForeignKey(cr => cr.RatingId);
+
+            modelBuilder.Entity<PlayerProfile>()
+                .HasOne(pp => pp.Game)
+                .WithMany(g => g.PlayerProfiles)
+                .HasForeignKey(pp => pp.GameId);
+            modelBuilder.Entity<PlayerProfile>()
+                .HasOne(pp => pp.User)
+                .WithMany(u => u.PlayerProfiles)
+                .HasForeignKey(pp => pp.UserId)
+                .OnDelete(DeleteBehavior.NoAction);
+            modelBuilder.Entity<PlayerProfile>()
+                .HasMany(pp => pp.Ratings)
+                .WithOne(r => r.PlayerProfile)
+                .HasForeignKey(r => r.PlayerProfileId)
+                .OnDelete(DeleteBehavior.NoAction);
         }
         public DbSet<User> Users { get; set; }
         public DbSet<Game> Games { get; set; }
@@ -30,5 +45,6 @@ namespace Storage
         public DbSet<Summary> Summaries { get; set; }
         public DbSet<Category> Categories { get; set; }
         public DbSet<CategoryRating> CategoryRatings { get; set; }
+        public DbSet<PlayerProfile> PlayerProfiles { get; set; }
     }
 }

--- a/Storage/Migrations/20201025113649_AddPlayerProfilesTable.Designer.cs
+++ b/Storage/Migrations/20201025113649_AddPlayerProfilesTable.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Storage;
 
 namespace Storage.Migrations
 {
     [DbContext(typeof(JudgeContext))]
-    partial class JudgeContextModelSnapshot : ModelSnapshot
+    [Migration("20201025113649_AddPlayerProfilesTable")]
+    partial class AddPlayerProfilesTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Storage/Migrations/20201025113649_AddPlayerProfilesTable.cs
+++ b/Storage/Migrations/20201025113649_AddPlayerProfilesTable.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Storage.Migrations
+{
+    public partial class AddPlayerProfilesTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Ratings_Users_UserId",
+                table: "Ratings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Ratings_UserId",
+                table: "Ratings");
+
+            migrationBuilder.DropColumn(
+                name: "Nickname",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "Ratings");
+
+            migrationBuilder.AddColumn<int>(
+                name: "PlayerProfileId",
+                table: "Ratings",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "PlayerProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Nickname = table.Column<string>(nullable: true),
+                    UserId = table.Column<int>(nullable: true),
+                    GameId = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PlayerProfiles_Games_GameId",
+                        column: x => x.GameId,
+                        principalTable: "Games",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PlayerProfiles_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Ratings_PlayerProfileId",
+                table: "Ratings",
+                column: "PlayerProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerProfiles_GameId",
+                table: "PlayerProfiles",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerProfiles_UserId",
+                table: "PlayerProfiles",
+                column: "UserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Ratings_PlayerProfiles_PlayerProfileId",
+                table: "Ratings",
+                column: "PlayerProfileId",
+                principalTable: "PlayerProfiles",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Ratings_PlayerProfiles_PlayerProfileId",
+                table: "Ratings");
+
+            migrationBuilder.DropTable(
+                name: "PlayerProfiles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Ratings_PlayerProfileId",
+                table: "Ratings");
+
+            migrationBuilder.DropColumn(
+                name: "PlayerProfileId",
+                table: "Ratings");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Nickname",
+                table: "Users",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UserId",
+                table: "Ratings",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Ratings_UserId",
+                table: "Ratings",
+                column: "UserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Ratings_Users_UserId",
+                table: "Ratings",
+                column: "UserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/Storage/Migrations/20201026112636_AddPlayerProfilesTable.Designer.cs
+++ b/Storage/Migrations/20201026112636_AddPlayerProfilesTable.Designer.cs
@@ -10,7 +10,7 @@ using Storage;
 namespace Storage.Migrations
 {
     [DbContext(typeof(JudgeContext))]
-    [Migration("20201025113649_AddPlayerProfilesTable")]
+    [Migration("20201026112636_AddPlayerProfilesTable")]
     partial class AddPlayerProfilesTable
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -119,10 +119,9 @@ namespace Storage.Migrations
 
             modelBuilder.Entity("Storage.Tables.PlayerProfile", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("GameId")
                         .HasColumnType("int");
@@ -152,8 +151,8 @@ namespace Storage.Migrations
                     b.Property<int>("ItemId")
                         .HasColumnType("int");
 
-                    b.Property<int>("PlayerProfileId")
-                        .HasColumnType("int");
+                    b.Property<string>("PlayerProfileId")
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<float>("TotalScore")
                         .HasColumnType("real");
@@ -276,8 +275,7 @@ namespace Storage.Migrations
                     b.HasOne("Storage.Tables.PlayerProfile", "PlayerProfile")
                         .WithMany("Ratings")
                         .HasForeignKey("PlayerProfileId")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.NoAction);
                 });
 #pragma warning restore 612, 618
         }

--- a/Storage/Migrations/20201026112636_AddPlayerProfilesTable.cs
+++ b/Storage/Migrations/20201026112636_AddPlayerProfilesTable.cs
@@ -22,18 +22,16 @@ namespace Storage.Migrations
                 name: "UserId",
                 table: "Ratings");
 
-            migrationBuilder.AddColumn<int>(
+            migrationBuilder.AddColumn<string>(
                 name: "PlayerProfileId",
                 table: "Ratings",
-                nullable: false,
-                defaultValue: 0);
+                nullable: true);
 
             migrationBuilder.CreateTable(
                 name: "PlayerProfiles",
                 columns: table => new
                 {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Id = table.Column<string>(nullable: false),
                     Nickname = table.Column<string>(nullable: true),
                     UserId = table.Column<int>(nullable: true),
                     GameId = table.Column<int>(nullable: false)

--- a/Storage/Migrations/JudgeContextModelSnapshot.cs
+++ b/Storage/Migrations/JudgeContextModelSnapshot.cs
@@ -117,10 +117,9 @@ namespace Storage.Migrations
 
             modelBuilder.Entity("Storage.Tables.PlayerProfile", b =>
                 {
-                    b.Property<int>("Id")
+                    b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("GameId")
                         .HasColumnType("int");
@@ -150,8 +149,8 @@ namespace Storage.Migrations
                     b.Property<int>("ItemId")
                         .HasColumnType("int");
 
-                    b.Property<int>("PlayerProfileId")
-                        .HasColumnType("int");
+                    b.Property<string>("PlayerProfileId")
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<float>("TotalScore")
                         .HasColumnType("real");
@@ -274,8 +273,7 @@ namespace Storage.Migrations
                     b.HasOne("Storage.Tables.PlayerProfile", "PlayerProfile")
                         .WithMany("Ratings")
                         .HasForeignKey("PlayerProfileId")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.NoAction);
                 });
 #pragma warning restore 612, 618
         }

--- a/Storage/Repositories/Interfaces/IPlayerProfileRepository.cs
+++ b/Storage/Repositories/Interfaces/IPlayerProfileRepository.cs
@@ -1,0 +1,6 @@
+﻿using Storage.Tables;
+
+namespace Storage.Repositories.Interfaces
+{
+    public interface IPlayerProfileRepository : IBaseRepository<PlayerProfile> { }
+}

--- a/Storage/Repositories/PlayerProfileRepository.cs
+++ b/Storage/Repositories/PlayerProfileRepository.cs
@@ -1,0 +1,10 @@
+﻿using Storage.Repositories.Interfaces;
+using Storage.Tables;
+
+namespace Storage.Repositories
+{
+    public class PlayerProfileRepository : BaseRepository<JudgeContext, PlayerProfile>, IPlayerProfileRepository
+    {
+        public PlayerProfileRepository(JudgeContext context) : base(context) { }
+    }
+}

--- a/Storage/ServiceCollectionExtension.cs
+++ b/Storage/ServiceCollectionExtension.cs
@@ -22,6 +22,7 @@ namespace Storage
             services.AddScoped<ICategoryRepository, CategoryRepository>();
             services.AddScoped<ICategoryRatingRepository, CategoryRatingRepository>();
             services.AddScoped<IUserRepository, UserRepository>();
+            services.AddScoped<IPlayerProfileRepository, PlayerProfileRepository>();
             return services;
         }
     }

--- a/Storage/Storage.csproj
+++ b/Storage/Storage.csproj
@@ -11,6 +11,10 @@
     <Compile Remove="Migrations\20201014104141_InitDatabase.Designer.cs" />
     <Compile Remove="Migrations\20201025112538_AddPlayerProfilesTable.cs" />
     <Compile Remove="Migrations\20201025112538_AddPlayerProfilesTable.Designer.cs" />
+    <Compile Remove="Migrations\20201025113649_AddPlayerProfilesTable.cs" />
+    <Compile Remove="Migrations\20201025113649_AddPlayerProfilesTable.Designer.cs" />
+    <Compile Remove="Migrations\20201026111938_AlterProfileIdToString.cs" />
+    <Compile Remove="Migrations\20201026111938_AlterProfileIdToString.Designer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Storage/Storage.csproj
+++ b/Storage/Storage.csproj
@@ -9,6 +9,8 @@
     <Compile Remove="Migrations\20201014103105_InitDatabase.Designer.cs" />
     <Compile Remove="Migrations\20201014104141_InitDatabase.cs" />
     <Compile Remove="Migrations\20201014104141_InitDatabase.Designer.cs" />
+    <Compile Remove="Migrations\20201025112538_AddPlayerProfilesTable.cs" />
+    <Compile Remove="Migrations\20201025112538_AddPlayerProfilesTable.Designer.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Storage/Tables/Game.cs
+++ b/Storage/Tables/Game.cs
@@ -23,5 +23,7 @@ namespace Storage.Tables
         public virtual ICollection<Item> Items { get; set; }
         [JsonIgnore]
         public ICollection<Category> Categories { get; set; }
+        [JsonIgnore]
+        public ICollection<PlayerProfile> PlayerProfiles { get; set; }
     }
 }

--- a/Storage/Tables/PlayerProfile.cs
+++ b/Storage/Tables/PlayerProfile.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Newtonsoft.Json;
+
+namespace Storage.Tables
+{
+    public class PlayerProfile
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Nickname { get; set; }
+        public int? UserId { get; set; }
+        [JsonIgnore]
+        public User User { get; set; }
+        public int GameId { get; set; }
+        [JsonIgnore]
+        public Game Game { get; set; }
+        [JsonIgnore]
+        public virtual ICollection<Rating> Ratings { get; set; }
+    }
+}

--- a/Storage/Tables/PlayerProfile.cs
+++ b/Storage/Tables/PlayerProfile.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using Newtonsoft.Json;
 
 namespace Storage.Tables
@@ -7,7 +8,8 @@ namespace Storage.Tables
     public class PlayerProfile
     {
         [Key]
-        public int Id { get; set; }
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public string Id { get; set; }
         public string Nickname { get; set; }
         public int? UserId { get; set; }
         [JsonIgnore]

--- a/Storage/Tables/Rating.cs
+++ b/Storage/Tables/Rating.cs
@@ -10,9 +10,9 @@ namespace Storage.Tables
         [ForeignKey(nameof(Item))]
         public int ItemId { get; set; }
         public Item Item { get; set; }
-        [ForeignKey(nameof(User))]
-        public int? UserId { get; set; }
-        public User User { get; set; }
+        [ForeignKey(nameof(PlayerProfile))]
+        public int PlayerProfileId { get; set; }
+        public PlayerProfile PlayerProfile { get; set; }
         public ICollection<CategoryRating> CategoryRatings { get; set; }
     }
 }

--- a/Storage/Tables/Rating.cs
+++ b/Storage/Tables/Rating.cs
@@ -11,7 +11,7 @@ namespace Storage.Tables
         public int ItemId { get; set; }
         public Item Item { get; set; }
         [ForeignKey(nameof(PlayerProfile))]
-        public int PlayerProfileId { get; set; }
+        public string PlayerProfileId { get; set; }
         public PlayerProfile PlayerProfile { get; set; }
         public ICollection<CategoryRating> CategoryRatings { get; set; }
     }

--- a/Storage/Tables/User.cs
+++ b/Storage/Tables/User.cs
@@ -8,12 +8,11 @@ namespace Storage.Tables
         public int Id { get; set; }
         public string Email { get; set; }
         public string Name { get; set; }
-        public string Nickname { get; set; }
         public string ProviderId { get; set; }
         public string ProviderName { get; set; }
         [JsonIgnore]
-        public virtual ICollection<Game> Games { get; set; }
+        public virtual ICollection<Game> OwnedGames { get; set; }
         [JsonIgnore]
-        public virtual ICollection<Rating> Ratings { get; set; }
+        public virtual ICollection<PlayerProfile> PlayerProfiles { get; set; }
     }
 }

--- a/WebApi/Controllers/AuthenticationController.cs
+++ b/WebApi/Controllers/AuthenticationController.cs
@@ -1,14 +1,9 @@
 ﻿using System.Threading.Tasks;
-using Authorization.Requests;
 using Authorization.Services.Interfaces;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Authentication.Facebook;
-using Microsoft.AspNetCore.Authentication.Google;
+using Core.Dto;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 
 namespace WebApi.Controllers
 {
@@ -17,65 +12,36 @@ namespace WebApi.Controllers
     public class AuthenticationController : ControllerBase
     {
         private readonly IAuthService _authService;
-        private readonly IConfiguration _configuration;
 
-        public AuthenticationController(IAuthService authService, IConfiguration configuration)
+        public AuthenticationController(IAuthService authService)
         {
             _authService = authService;
-            _configuration = configuration;
-        }
-
-        [HttpPost]
-        [Route("register")]
-        [ProducesResponseType(StatusCodes.Status201Created)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> Register(RegisterRequest request)
-        {
-            var token = await _authService.Register(request);
-            if (token == null) 
-                return NotFound();
-
-            return Ok(token);
-        }
-        
-        [HttpGet]
-        [ProducesResponseType(StatusCodes.Status302Found)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        [Route("login/google")]
-        public IActionResult GoogleLogin()
-        {
-
-            var properties = new AuthenticationProperties
-            {
-                RedirectUri = Url.Action("SocialLogin")
-            };
-
-            return Challenge(properties, GoogleDefaults.AuthenticationScheme);
         }
 
         [HttpGet]
-        [ProducesResponseType(StatusCodes.Status302Found)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [Route("login/facebook")]
-        public IActionResult FacebookLogin()
+        public async Task<IActionResult> FacebookLogin([FromQuery] string accessToken)
         {
-            var properties = new AuthenticationProperties
+            var user = await _authService.AuthorizeFacebookUser(accessToken);
+            if(user == null)
             {
-                RedirectUri = Url.Action("SocialLogin")
-            };
+                return Unauthorized();
+            }
 
-            return Challenge(properties, FacebookDefaults.AuthenticationScheme);
+            string token = _authService.GetUserToken(user);
+            return Ok(new TokenDto(token));
         }
 
-        [HttpGet]
-        [ProducesResponseType(StatusCodes.Status302Found)]
-        [Route("login/social")]
-        public async Task<IActionResult> SocialLogin()
-        {
-            var result = await HttpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-            var token = await _authService.GetToken(result);
 
-            return Redirect(_configuration.GetSection("JwtToken")["DestinationUrl"] + token);
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [Route("login/guest")]
+        public IActionResult GuestLogin()
+        {
+            string token =_authService.GetGuestToken();
+            return Ok(new TokenDto(token));
         }
     }
 }

--- a/WebApi/Controllers/CategoriesController.cs
+++ b/WebApi/Controllers/CategoriesController.cs
@@ -27,7 +27,7 @@ namespace WebApi.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<List<Category>> GetCategoriesByGameId(int gameId)
         {
-           return await _categoryService.GetCategoriesByGameId(gameId);
+            return await _categoryService.GetCategoriesByGameId(gameId);
         }
 
         [HttpPost]

--- a/WebApi/Hubs/IGameClient.cs
+++ b/WebApi/Hubs/IGameClient.cs
@@ -12,5 +12,6 @@ namespace WebApi.Hubs
         Task SendMessage(string message);
         Task DisbandGame(string message);
         Task ShowSummary(Summary summary);
+        Task SendPlayerProfileId(string profileId);
     }
 }

--- a/WebApi/appsettings.json
+++ b/WebApi/appsettings.json
@@ -13,12 +13,10 @@
 
   "Authentication": {
     "Google": {
-      "ClientId": "",
-      "ClientSecret": ""
     },
     "Facebook": {
-      "AppId": "",
-      "AppSecret": ""
+      "GraphHostname": "https://graph.facebook.com",
+      "GetUserPath": "/v8.0/me?"
     }
   },
 
@@ -26,7 +24,6 @@
     "SecretKey": "",
     "Issuer": "https://localhost:44341",
     "Audience": "https://localhost:44341",
-    "TokenExpiry": "120",
-    "DestinationUrl": ""
+    "TokenExpiry": "120"
   }
 }


### PR DESCRIPTION
This pull request:
1. Drops built-in cookie based Facebook and Google authorization. API now takes access token issued by facebook and fetches facebook profile data by communication with Facebook Graph API.
2. Adds PlayerProfiles table which assigns users (or guests) to games. Ratings are now owned by PlayerProfiles instead of Users.

Closes #30 